### PR TITLE
lj-releng: get the `loadstring` global variable at the top level is expected.

### DIFF
--- a/lj-releng
+++ b/lj-releng
@@ -177,7 +177,7 @@ sub process_file {
                                    |os|print|tonumber|math|pcall|xpcall|unpack
                                    |pairs|ipairs|assert|module|package
                                    |coroutine|[gs]etfenv|next|rawget|rawset
-                                   |rawlen|select|arg|bit|debug|ngx|ndk)$/x)
+                                   |rawlen|select|arg|bit|debug|loadstring)$/x)
                 {
                     next;
                 }


### PR DESCRIPTION
there are duplicated `ngx|ndk`.