### PR TITLE
bugfix: ngx-build: applied missing patches and do not apply recent CVE patches to old NGINX cores.

### DIFF
--- a/ngx-build
+++ b/ngx-build
@@ -221,6 +221,10 @@ sub apply_patches {
         shell("patch -p0 < $root/../no-pool-nginx/nginx-$version-no_pool.patch");
     }
 
+    unless ($ver lt '001009003') {
+        shell("patch -p0 < $root/../openresty/patches/nginx-$version-always_enable_cc_feature_tests.patch");
+    }
+
     if ($ver lt '001000014' || ($ver ge '001001000' && $ver lt '001001017')) {
         chdir "nginx-$version" or die "cannot switch to nginx-$version\n";
         warn "applying the null char fixes security patch";
@@ -297,9 +301,9 @@ sub apply_patches {
     }
     #shell("patch -p0 < $root/../openresty/patches/nginx-$version-gzip_ok_invalid_read_fix.patch");
 
-    unless ($ver ge '001000009') {
-        shell("patch -p0 < $root/../openresty/patches/nginx-$version-log_escape_non_ascii.patch");
-    }
+    chdir "nginx-$version" or die "cannot switch to nginx-$version\n";
+    shell("patch -p1 < $root/../openresty/patches/nginx-$version-log_escape_non_ascii.patch");
+    chdir ".." or die "cannot switch to ..\n";
 
     unless ($ver ge '001005003') {
         shell("patch -p0 < $root/../openresty/patches/nginx-$version-upstream_truncation.patch");
@@ -490,6 +494,7 @@ sub apply_patches {
         shell("patch -p1 < $root/../openresty/patches/nginx-$version-stream_ssl_preread_no_skip.patch");
         shell("patch -p1 < $root/../openresty/patches/nginx-$version-resolver_conf_parsing.patch");
         shell("patch -p1 < $root/../openresty/patches/nginx-$version-socket_cloexec.patch");
+        shell("patch -p1 < $root/../openresty/patches/nginx-$version-daemon_destroy_pool.patch");
         chdir ".." or die "cannot switch to ..\n";
     }
 
@@ -501,9 +506,8 @@ sub apply_patches {
         chdir ".." or die "cannot switch to ..\n";
     }
 
-    if ($ver ge '001009005' && $ver lt '001014001'
-        || $ver ge '001015000' && $ver lt '001015006')
-    {
+    if ($ver ge '001015000' && $ver lt '001015006') {
+        # 1.9.5 to 1.14.0 (included) are alro vulnerable, but this patch does not apply
         chdir "nginx-$version" or die "cannot switch to nginx-$version\n";
         shell("patch -p0 < $root/../openresty/patches/patch.2018.h2.txt");
         chdir ".." or die "cannot switch to ..\n";
@@ -515,9 +519,11 @@ sub apply_patches {
         chdir ".." or die "cannot switch to ..\n";
     }
 
-    if ($ver ge '001009005' && $ver lt '001016001'
+    if ($ver ge '001015006' && $ver lt '001016001'
         || $ver ge '001017000' && $ver lt '001017003')
     {
+        # 1.9.5 to 1.16.0 (included) are alro vulnerable, but this patch only
+        # applies to 1.15.6+
         chdir "nginx-$version" or die "cannot switch to nginx-$version\n";
         shell("patch -p0 < $root/../openresty/patches/patch.2019.h2.txt");
         chdir ".." or die "cannot switch to ..\n";


### PR DESCRIPTION
* Do not apply the 2018.h2 patch to NGINX cores < 1.15.0.
* Do not apply the 2019.h2 patch to NGINX cores < 1.15.6.
* The `log_escape_non_ascii` patch is now applied to devel builds.
* The `always_enable_cc_feature_tests` is now applied to devel builds.
* The `daemon_destroy_pool` patch is now applied to devel builds.

Those three patches are always applied to the NGINX cores shipping in
release tarballs.

Diff of nginx-dev-build-master (prior) and nginx-dev-build-refactor
(after this patch) with NGINX core 1.17.1:

    $ diff -yr --suppress-common-lines -x '*.o' ./nginx-dev-build-master/auto/cc/conf ./nginx-dev-build-refactor/auto/cc/conf
    if [ "$NGX_PLATFORM" != win32 ]; then         | if [ 1 ]; then
    Only in ./nginx-dev-build-refactor/auto/cc: conf.orig
    diff -yr --suppress-common-lines -x '*.o' ./nginx-dev-build-master/src/http/modules/ngx_http_log_module.c ./nginx-dev-build-refactor/src/http/modules/ngx_http_log_module.c
                 >     ngx_flag_t                  escape_non_ascii;
                 >
    static uintptr_t ngx_http_log_escape(u_char *dst, u_char *src | static uintptr_t ngx_http_log_escape(ngx_http_log_loc_conf_t
                 >     u_char *src, size_t size);
                 >     { ngx_string("log_escape_non_ascii"),
                 >       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|
                 >       ngx_conf_set_flag_slot,
                 >       NGX_HTTP_LOC_CONF_OFFSET,
                 >       offsetof(ngx_http_log_loc_conf_t, escape_non_ascii),
                 >       NULL },
                 >
                 >     ngx_http_log_loc_conf_t    *lcf;
        len = ngx_http_log_escape(NULL, value->data, value->len); |     lcf = ngx_http_get_module_loc_conf(r, ngx_http_log_module
                 >
                 >     len = ngx_http_log_escape(lcf, NULL, value->data, value->
                 >     ngx_http_log_loc_conf_t    *lcf;
            return (u_char *) ngx_http_log_escape(buf, value->dat |         lcf = ngx_http_get_module_loc_conf(r, ngx_http_log_mo
                 >         return (u_char *) ngx_http_log_escape(lcf, buf, value
    ngx_http_log_escape(u_char *dst, u_char *src, size_t size)    | ngx_http_log_escape(ngx_http_log_loc_conf_t *lcf, u_char *dst
                 >     size_t size)
        ngx_uint_t      n;           |     ngx_uint_t                   n;
        static u_char   hex[] = "0123456789ABCDEF";        |     static u_char                hex[] = "0123456789ABCDEF";
                 >     if (lcf->escape_non_ascii) {
                 >         ngx_memset(&escape[4], 0xff, sizeof(uint32_t) * 4);
                 >
                 >     } else {
                 >         ngx_memzero(&escape[4], sizeof(uint32_t) * 4);
                 >     }
                 >     conf->escape_non_ascii = NGX_CONF_UNSET;
                 >
                 >     ngx_conf_merge_value(conf->escape_non_ascii, prev->escape
    Only in ./nginx-dev-build-refactor/src/http/modules: ngx_http_log_module.c.orig
    diff -yr --suppress-common-lines -x '*.o' ./nginx-dev-build-master/src/os/unix/ngx_daemon.c ./nginx-dev-build-refactor/src/os/unix/ngx_daemon.c
                 >         /* just to make it ASAN or Valgrind clean */
                 >         ngx_destroy_pool(ngx_cycle->pool);