### PR TITLE
ngx-build: removed the gcc-maybe-initialized-warning patch.

### DIFF
--- a/ngx-build
+++ b/ngx-build
@@ -367,10 +367,6 @@ sub apply_patches {
         chdir ".." or die "cannot switch to ..\n";
     }
 
-    if ($ver ge '001004001') {
-        shell("patch -p0 < $root/../openresty/patches/nginx-$version-gcc-maybe-uninitialized-warning.patch");
-    }
-
     unless ($ver ge '001005003') {
         shell("patch -p0 < $root/../openresty/patches/nginx-$version-unix_socket_accept_over_read.patch");
     }


### PR DESCRIPTION
This was fixed in the 1.5.10 release. We unconditionally remove it since
we only support NGINX cores 1.6.0 and above.

Sister PR: https://github.com/openresty/openresty/pull/576