### PR TITLE
feature: check blank line for block(struct/function)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Table of Contents
 * [Description](#description)
     * [ngx-build](#ngx-build)
     * [reindex](#reindex)
+    * [ngx-style.pl](#ngx-style.pl)
 * [Copyright & License](#copyright--license)
 
 Description
@@ -256,6 +257,38 @@ its default option is `1`.
 ```
 reindex -b 0 /path/to/module/t*.t
 ```
+
+[Back to TOC](#table-of-contents)
+
+ngx-style.pl
+---------
+
+The `ngx-style.pl` is used to unify the code style of nginx C source code, and it also work for other nginx C modules,
+such as all C modules under [the git reposity of Openresty](https://github.com/openresty).
+You can install this tool like tools mentioned above.
+
+You can run `ngx-style.pl` like this:
+```
+ngx-style.pl /path/to/module/src/*
+```
+
+If a problem is found, the problem file, the description of the problem, and the line number and content of the problem
+will be reported. Below is an example:
+```
+src/ngx_http_lua_variable.c:
+found line tailing spaces
+22:     ngx_uint_t                   hash;   
+```
+
+The `ngx-style.pl` will check the code style problems like these:
+* Check that each line does not end with DOS line ending, or report `found DOS line ending`.
+* Check that each line does not end with space, or report `found line tailing spaces`.
+* Check if there is no space before the comma in each line, or report `do not need space before ,`.
+* Check if every line has spaces after the comma, or report `need one space after ,`.
+* Check if every line has spaces after the right parenthesis, or report `need one space after )`.
+* ... ...
+
+We will continue to update this rule base on the issues we find, and your commit is wellcome.
 
 [Back to TOC](#table-of-contents)
 

--- a/ngx-style.pl
+++ b/ngx-style.pl
@@ -46,10 +46,6 @@ for my $file (@ARGV) {
 
         #print "$lineno: $line";
 
-        if ($line =~ /vi:set/) {
-            last;
-        }
-
         if ($line =~ /\r\n$/) {
             output "found DOS line ending";
         }
@@ -269,10 +265,17 @@ for my $file (@ARGV) {
             } else {
                 $just_leave_block = 0;
 
-                if ($blank_between_block != 0) {
-                    my $blank_line = 2 - $blank_between_block;
-                    output "found $blank_line blank line between blocks";
-                }
+                #if ($line =~ /^\/\* vi:set/) {
+                #    if ($blank_between_block != 1) {
+                #        my $blank_line = 2 - $blank_between_block;
+                #        output "found $blank_line blank line before vi:set";
+                #    }
+                #} else {
+                #    if ($blank_between_block != 0) {
+                #        my $blank_line = 2 - $blank_between_block;
+                #        output "found $blank_line blank line between blocks";
+                #    }
+                #}
             }
         }
 


### PR DESCRIPTION
When we review PR, we will always find a lot of style problems, especially the blank line problem is difficult to find. This PR enhance this tool and make some judgments about blank lines.

such as: 
https://github.com/openresty/lua-ssl-nginx-module/pull/17/files#diff-d4b375c227fd2cf54f088b2d9f2c511fR80
https://github.com/openresty/set-misc-nginx-module/pull/58/files#diff-b16fdf856ddbb9b2cb8daa820f7c3869R51
https://github.com/openresty/lua-nginx-module/pull/1707/files#diff-1ef280d293b3f018e2d483625a638731R5085