### PR TITLE
ngx-build: added the static_mod_escape_loc_hdr patch for NGINX core 

### DIFF
--- a/ngx-build
+++ b/ngx-build
@@ -318,6 +318,12 @@ sub apply_patches {
 
     chdir ".." or die "cannot switch to ..\n";
 
+    if ($ver ge '001017008') {
+        chdir "nginx-$version" or die "cannot switch to nginx-$version\n";
+        shell("patch -p1 < $root/../openresty/patches/nginx-$version-static_mod_escape_loc_hdr.patch");
+        chdir ".." or die "cannot switch to ..\n";
+    }
+
     unless ($ver ge '001005003') {
         shell("patch -p0 < $root/../openresty/patches/nginx-$version-channel-uninit-params.patch");
     }


### PR DESCRIPTION
goto https://hackerone.com/reports/513236 and https://github.com/openresty/openresty/pull/611 for details.