### PR TITLE
ngx-style: allow > 2 spaces in struct typedef

### DIFF
--- a/ngx-style.pl
+++ b/ngx-style.pl
@@ -102,7 +102,7 @@ for my $file (@ARGV) {
         }
 
         if ($line =~ /^typedef struct \w+( *)(\w+);/) {
-            if (length($1) != 2) {
+            if (length($1) < 2) {
                 output "need two space before $2";
             }
         }


### PR DESCRIPTION
when forward declaring multiple structs, the type names are aligned to
the same column (like variable declarations).
for example -
https://github.com/nginx/nginx/blob/master/src/http/ngx_http.h#L16