### PR TITLE
ngx-releng: add \t  check 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "github.copilot.enable": {
+        "*": false,
+        "plaintext": false,
+        "markdown": false,
+        "scminput": false
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,0 @@
-{
-    "github.copilot.enable": {
-        "*": false,
-        "plaintext": false,
-        "markdown": false,
-        "scminput": false
-    }
-}

--- a/ngx-releng
+++ b/ngx-releng
@@ -35,8 +35,8 @@ if [ -d src ]; then
     ack '(?<=\#define)\s*DDEBUG\s*[1-9]' src /dev/null
     ack '\(\);' $hfiles /dev/null
     ack '^\w+[^()]*?\*\s\w+' $hfiles /dev/null
-    ack '.{81}' $cfiles /dev/null
-    ack '[ \t]+$' $cfiles /dev/null
+    ack '.{81}' $cfiles $hfiles /dev/null
+    ack '[ \t]+$' $cfiles $hfiles /dev/null
     ack '(?<!:)//' $cfiles /dev/null
     ack '^\s*?\t\s*\S' $cfiles /dev/null
     ack '^static .*?\(\);' $cfiles /dev/null
@@ -47,6 +47,7 @@ if [ -d src ]; then
     ack 'if \( |if \(! |if \(.*? \)' $cfiles /dev/null
     ack '\b(?:if|for|while|switch)\(|\bdo\{' $cfiles /dev/null
     ack '^\#\s*define\s+ngx_[a-z]+_\w+?_version\s+\d+' $cfiles /dev/null
+    ack '\t' $cfiles $hfiles /dev/null
 
     perl -e 'use strict; use warnings;
         for my $fname (@ARGV) {


### PR DESCRIPTION
### Brackground

While I PR to the https://github.com/openresty/lua-nginx-module/pull/2412, it will run the check like this: 
```
before_install:
  - '! grep -n -P ''(?<=.{80}).+'' --color `find src -name ''*.c''` `find . -name ''*.h''` || (echo "ERROR: Found C source lines exceeding 80 columns." > /dev/stderr; exit 1)'
  - '! grep -n -P ''\t+'' --color `find src -name ''*.c''` `find . -name ''*.h''` || (echo "ERROR: Cannot use tabs." > /dev/stderr; exit 1)'
  - /usr/bin/env perl $(command -v cpanm) --sudo --notest Test::Nginx IPC::Run > build.log 2>&1 || (cat build.log && exit 1)
```
https://app.travis-ci.com/github/openresty/lua-nginx-module/jobs/632424434



### Key Change

- Add  `\t` check for $cfiles $hfiles
- Add 80 length code limitation to  $cfiles $hfiles